### PR TITLE
Subir funciones que relacionan los botones del header con el aside co…

### DIFF
--- a/app.js
+++ b/app.js
@@ -12,6 +12,11 @@ const textoInferiorMeme = document.getElementById("texto-inf-meme");
 const sinTextoSuperior = document.getElementById("sin-texto-superior");
 const sinTextoInferior = document.getElementById("sin-texto-inferior");
 
+const botonImagen = document.querySelector('#boton-imagen');
+const botonTexto = document.querySelector('#boton-texto');
+const panelImagen = document.getElementById('panel-imagen');
+const panelTexto = document.getElementById('panel-texto');
+
 // URL de la imagen asociada a la sección del meme
 inputURL.onkeyup = (event) => {
     
@@ -62,4 +67,20 @@ sinTextoInferior.onchange = () => {
     else{
         textoInferiorMeme.classList.remove('no-mostrar-texto');
     }
+};
+
+// Funciones para que al hacer click en algún botón del header, me abra el aside correspondiente
+
+botonImagen.onclick = () => {
+
+    panelImagen.classList.remove('no-mostrar-panel');
+    panelTexto.classList.add('no-mostrar-panel');
+   
+};
+
+botonTexto.onclick = () => {
+
+    panelImagen.classList.add('no-mostrar-panel');
+    panelTexto.classList.remove('no-mostrar-panel');
+
 };

--- a/index.html
+++ b/index.html
@@ -18,8 +18,8 @@
     <header>
         <h1 class="tituloTP">Generador de Memes</h1>
         <div class="panelDeBotones">
-            <button class="boton"><i class="fas fa-file-image"></i> Imagen</button>
-            <button class="boton"><i class="fas fa-font"></i> Texto</button>
+            <button class="boton" id="boton-imagen"><i class="fas fa-file-image"></i> Imagen</button>
+            <button class="boton" id="boton-texto"><i class="fas fa-font"></i> Texto</button>
             <button class="boton"><i class="fas fa-lightbulb"></i> Modo oscuro</button>
         </div>
     </header>
@@ -47,7 +47,7 @@
       </main>
 
     <!-- INICIO SECCION PANEL IMAGEN -->
-    <aside>
+    <aside id="panel-imagen" class="no-mostrar-panel">
         <button aria-label="cerrar panel imagen"><i class="fas fa-times"></i></button>
     <section>
         <h2>IMAGEN</h2>
@@ -148,7 +148,7 @@
     <!-- FIN PANEL IMAGEN -->
 
     <!-- INICIO PANEL TEXTO -->
-    <aside>
+    <aside id="panel-texto" class="no-mostrar-panel">
         <button aria-label="cerrar panel texto"><i class="fas fa-times"></i></button>
         <section>
             <h2>TEXTO</h2>

--- a/style.css
+++ b/style.css
@@ -245,6 +245,6 @@ input[type="range"] {
 
   /* Desaparecer texto del meme */
 
-  .no-mostrar-texto {
+  .no-mostrar-texto, .no-mostrar-panel {
     display: none;
   }


### PR DESCRIPTION
…rrespondiente

Al darle click al botón imagen del header, se muestra el aside que contiene las opciones de la imagen, lo mismo ocurre con el botón texto, pero se abre el aside con las opciones de texto.

Al cargar la página por primera vez no me muestra ninguno de los dos paneles porque ambos asides inician con la clase 'no-mostrar-panel'

En el siguiente branch voy a trabajar en una función que me haga aparecer el panel de imagen por defecto