### PR TITLE
Agregar función que cierra los paneles en la vista mobile

### DIFF
--- a/app.js
+++ b/app.js
@@ -17,6 +17,11 @@ const botonTexto = document.querySelector('#boton-texto');
 const panelImagen = document.getElementById('panel-imagen');
 const panelTexto = document.getElementById('panel-texto');
 
+const cierrePanelImagen = document.getElementById("cierre-panel-imagen");
+const cierrePanelTexto = document.getElementById("cierre-panel-texto");
+
+
+
 // URL de la imagen asociada a la sección del meme
 inputURL.onkeyup = (event) => {
     
@@ -94,4 +99,19 @@ window.addEventListener('load' , () => {
         panelImagen.classList.remove('no-mostrar-panel');
         panelTexto.classList.add('no-mostrar-panel');
     }
-})
+});
+
+// Botoncito de cierre de los paneles
+
+cierrePanelImagen.addEventListener('click', () => {
+    // console.log('cierra')
+    panelImagen.classList.add('no-mostrar-panel');
+});
+
+cierrePanelTexto.addEventListener ('click', () => {
+
+    panelTexto.classList.add('no-mostrar-panel');
+});
+
+
+

--- a/index.html
+++ b/index.html
@@ -48,7 +48,7 @@
 
     <!-- INICIO SECCION PANEL IMAGEN -->
     <aside id="panel-imagen" class="no-mostrar-panel">
-        <button aria-label="cerrar panel imagen"><i class="fas fa-times"></i></button>
+        <button id="cierre-panel-imagen" class="close" aria-label="cerrar panel imagen" ><i class="fas fa-times"></i></button>
     <section>
         <h2>IMAGEN</h2>
         <!------------  URL ------------->
@@ -149,7 +149,7 @@
 
     <!-- INICIO PANEL TEXTO -->
     <aside id="panel-texto" class="no-mostrar-panel">
-        <button aria-label="cerrar panel texto"><i class="fas fa-times"></i></button>
+        <button id="cierre-panel-texto" class="close" aria-label="cerrar panel texto"><i class="fas fa-times"></i></button>
         <section>
             <h2>TEXTO</h2>
             <!----------- TEXTO SUPERIOR ----------->

--- a/style.css
+++ b/style.css
@@ -248,3 +248,11 @@ input[type="range"] {
   .no-mostrar-texto, .no-mostrar-panel {
     display: none;
   }
+
+  /* Cerrar panel*/
+
+  .close {
+    display: none;
+  }
+
+


### PR DESCRIPTION
En la vista de escritorio la cruz de cierre que estaba en los paneles no aparece, porque esa opción no esta en el modelo original. Tengo que acomodar los estilos para que aparezca en las vistas correspondientes